### PR TITLE
feat: Add a GitHub workflow to search for Discord Webhooks within a PR repo

### DIFF
--- a/.github/workflows/detect-discord-webhooks.yaml
+++ b/.github/workflows/detect-discord-webhooks.yaml
@@ -1,4 +1,4 @@
-name: 👀 Detect committed Discord webhooks
+name: 👀 Detect committed Discord Webhook
 run-name: 🔍 Searching for a Discord webhook token within commit contents 
 on: [pull_request]
 jobs:
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: 🆕 Check out repository code
         uses: actions/checkout@v4
-      - name: 🔍 Search for Discord webhook token
+      - name: 🔍 Search for a Discord Webhook token
         id: regex_search
         run: |
           set +e
@@ -22,7 +22,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '# 🔴 WEBHOOK URL DETECTED\n\n### A Discord webhook token has been detected within your commit contents.\n\nPlease refer to the `README.md` and use the `.env` file for inputting a webhook URL.\n\n*This PR will now be closed for your own safety, **please reset your webhook URL** as other people could use it to send messages to the channel where the webhook was created!*'
+              body: '# 🔴 WEBHOOK URL DETECTED\n\n### A Discord Webhook token has been detected within your commit contents.\n\nPlease refer to the `README.md` and use the `.env` file for inputting a Webhook URL.\n\n*This PR will now be closed for your own safety, **please reset your Webhook URL** as other people could use it to send messages to the channel where the Webhook was created!*'
             })
 
             github.rest.pulls.update({

--- a/.github/workflows/detect-discord-webhooks.yaml
+++ b/.github/workflows/detect-discord-webhooks.yaml
@@ -1,5 +1,5 @@
 name: 👀 Detect committed Discord Webhook
-run-name: 🔍 Searching for a Discord webhook token within commit contents 
+run-name: 🔍 Searching for a Discord Webhook URL within commit contents 
 on: [pull_request]
 jobs:
   detect-discord-webhooks:
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: 🆕 Check out repository code
         uses: actions/checkout@v4
-      - name: 🔍 Search for a Discord Webhook token
+      - name: 🔍 Search for a Discord Webhook URL
         id: regex_search
         run: |
           set +e
@@ -22,7 +22,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '# 🔴 WEBHOOK URL DETECTED\n\n### A Discord Webhook token has been detected within your commit contents.\n\nPlease refer to the `README.md` and use the `.env` file for inputting a Webhook URL.\n\n*This PR will now be closed for your own safety, **please reset your Webhook URL** as other people could use it to send messages to the channel where the Webhook was created!*'
+              body: '# 🔴 WEBHOOK URL DETECTED\n\n### A Discord Webhook URL has been detected within your commit contents.\n\nPlease refer to the `README.md` and use the `.env` file for inputting a Webhook URL.\n\n*This PR will now be closed for your own safety, **please reset your Webhook URL** as other people could use it to send messages to the channel where the Webhook was created!*'
             })
 
             github.rest.pulls.update({

--- a/.github/workflows/detect-discord-webhooks.yaml
+++ b/.github/workflows/detect-discord-webhooks.yaml
@@ -1,0 +1,33 @@
+name: 👀 Detect committed Discord webhooks
+run-name: 🔍 Searching for a Discord webhook token within commit contents 
+on: [pull_request]
+jobs:
+  detect-discord-webhooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🆕 Check out repository code
+        uses: actions/checkout@v4
+      - name: 🔍 Search for Discord webhook token
+        id: regex_search
+        run: |
+          set +e
+          git grep -P -q "(discord|discordapp).com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_.-])*" $(git rev-list --all)
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+      - name: 💬 Place a comment on the PR and close
+        if: steps.regex_search.outputs.exit_code == 0
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '# 🔴 WEBHOOK URL DETECTED\n\n### A Discord webhook token has been detected within your commit contents.\n\nPlease refer to the `README.md` and use the `.env` file for inputting a webhook URL.\n\n*This PR will now be closed for your own safety, **please reset your webhook URL** as other people could use it to send messages to the channel where the webhook was created!*'
+            })
+
+            github.rest.pulls.update({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })


### PR DESCRIPTION
This PR adds a GitHub workflow that automatically detects Discord Webhook URLs within commit contents. The workflow will give a message to the user explaining their mistake and close the PR.

For this to work, you need to go to your repo *Settings* tab, then *Actions > General* on the left and scroll to the bottom of the page to enable *Read and write permissions* under *Workflow permissions*.

See images linked below if you are lost, and a preview of the workflow output.

Workflow output: https://i.imgur.com/RHOiFKF.png
Actions tab: https://i.imgur.com/z47yfUX.png
Bottom of the actions tab: https://i.imgur.com/VrRWkkE.png

Closes #7 